### PR TITLE
Passive mode

### DIFF
--- a/squint.1.t2t
+++ b/squint.1.t2t
@@ -33,6 +33,20 @@ available to do any other stuff.
 do not enable screen duplication at startup. Use this option if you want to start squint automatically at the X session startup
 : **-l N, --limit N**
 limit the refresh rate to N frames per second (default is 50fps), use '-l' 0 to disable limitation (not recommended)
+: **-p, --passive**
+do not raise the window on user activity
+
+In normal mode, squint automatically raises or lowers its window on user
+activity. The window is raised when the activity happens inside the source
+monitor and lowered otherwise.
+
+In passive mode, the window is shown at startup but never raised or lowered
+afterwards. Squint ignores user interactions, it just dumbly duplicates the
+source monitor.
+
+Note: the passive mode is effective only when running in an ordinary window
+(see '-w'). In fullscreen mode this setting is ignored.
+
 : **-r N, --rate N**
 use fixed refresh rate of N frames per second (default to 25fps when the XDamage extension is not available)
 : **-v, --version**

--- a/squint.c
+++ b/squint.c
@@ -357,6 +357,9 @@ refresh_app_indicator()
 		case 2:
 			// passive button
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_passive);
+
+			// disable the button if running in fullscreen mode (because it has no effects)
+			gtk_widget_set_sensitive(item, config.opt_window);
 			break;
 		default:
 			// delete all other GtkTypeCheckMenuItem objects
@@ -692,7 +695,7 @@ squint_disable()
 GOptionEntry option_entries[] = {
   { "disable",	'd',	0,	G_OPTION_ARG_NONE,	&config.opt_disable,	"Do not enable screen duplication at startup", NULL},
   { "limit",	'l',	0,	G_OPTION_ARG_INT,	&config.opt_limit,	"Limit refresh rate to N frames per second", "N"},
-  { "passive",	'p',	0,	G_OPTION_ARG_NONE,	&config.opt_passive,	"Do not raise the window on user activity", NULL},
+  { "passive",	'p',	0,	G_OPTION_ARG_NONE,	&config.opt_passive,	"Do not raise the window on user activity (has no effects in fullscreen mode)", NULL},
   { "rate",	'r',	0,	G_OPTION_ARG_INT,	&config.opt_rate,	"Use fixed refresh rate of N frames per second", "N"},
   { "version",	'v',	0,	G_OPTION_ARG_NONE,	&config.opt_version,	"Display version information and exit", NULL},
   { "window",	'w',	0,	G_OPTION_ARG_NONE,	&config.opt_window,	"Run inside a window instead of going fullscreen", NULL},

--- a/squint.c
+++ b/squint.c
@@ -615,9 +615,6 @@ enable_window()
 		gtk_widget_show (gtkwin);
 		gdkwin = gtk_widget_get_window(gtkwin);
 
-		// hide it
-		gdk_window_lower(gdkwin);
-
 		// resize the window
 		int w = src_rect.width;
 		int max_w = dst_rect.width - 100;

--- a/squint.c
+++ b/squint.c
@@ -293,7 +293,7 @@ init_app_indicator()
 
 	// quiet
 	item = gtk_check_menu_item_new_with_label("Quiet");
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_quiet);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_quiet);
 	connect_menu_item(item, ITEM_QUIET);
 	gtk_menu_shell_append(menu.shell, item);
 

--- a/squint.c
+++ b/squint.c
@@ -87,10 +87,8 @@ squint_show()
 		raised = TRUE;
 		if (fullscreen) {
 			gtk_widget_show(gtkwin);
-		} else {
-      if (!config.opt_quiet) {
-        gdk_window_raise(gdkwin);
-      }
+		} else if (!config.opt_quiet) {
+			gdk_window_raise(gdkwin);
 		}
 	}
 }
@@ -101,10 +99,8 @@ do_hide()
 	raised = FALSE;
 	if (fullscreen) {
 		gtk_widget_hide(gtkwin);
-	} else {
-    if (!config.opt_quiet) {
-      gdk_window_lower(gdkwin);
-    }
+	} else if (!config.opt_quiet) {
+		gdk_window_lower(gdkwin);
 	}
 }
 

--- a/squint.c
+++ b/squint.c
@@ -87,7 +87,7 @@ squint_show()
 		raised = TRUE;
 		if (fullscreen) {
 			gtk_widget_show(gtkwin);
-		} else if (!config.opt_quiet) {
+		} else if (!config.opt_passive) {
 			gdk_window_raise(gdkwin);
 		}
 	}
@@ -99,7 +99,7 @@ do_hide()
 	raised = FALSE;
 	if (fullscreen) {
 		gtk_widget_hide(gtkwin);
-	} else if (!config.opt_quiet) {
+	} else if (!config.opt_passive) {
 		gdk_window_lower(gdkwin);
 	}
 }
@@ -139,11 +139,11 @@ on_window_delete_event(GtkWidget* widget, GdkEvent* event, gpointer data)
 #define ITEM_MASK		0xffffff00
 #define ITEM_ENABLE		(1<<8)
 #define ITEM_FULLSCREEN		(1<<9)
-#define ITEM_QUIET		(1<<14)
 #define ITEM_QUIT		(1<<10)
 #define ITEM_SRC_MONITOR	(1<<11)
 #define ITEM_DST_MONITOR	(1<<12)
 #define ITEM_ABOUT		(1<<13)
+#define ITEM_PASSIVE		(1<<14)
 #define ITEM_AUTO		0xff
 
 void
@@ -180,8 +180,8 @@ on_menu_item_activate(gpointer pointer, gpointer user_data)
 		}
 		break;
 
-	case ITEM_QUIET:
-		config.opt_quiet = !config.opt_quiet;
+	case ITEM_PASSIVE:
+		config.opt_passive = !config.opt_passive;
 		goto reset;
 
 	case ITEM_FULLSCREEN:
@@ -291,16 +291,16 @@ init_app_indicator()
 	gtk_menu_shell_append(menu.shell, item);
 	GtkWidget* enabled_item = item;
 
-	// quiet
-	item = gtk_check_menu_item_new_with_label("Quiet");
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_quiet);
-	connect_menu_item(item, ITEM_QUIET);
-	gtk_menu_shell_append(menu.shell, item);
-
 	// fullscreen
 	item = gtk_check_menu_item_new_with_label("Fullscreen");
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_window);
 	connect_menu_item(item, ITEM_FULLSCREEN);
+	gtk_menu_shell_append(menu.shell, item);
+
+	// passive
+	item = gtk_check_menu_item_new_with_label("Passive");
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_passive);
+	connect_menu_item(item, ITEM_PASSIVE);
 	gtk_menu_shell_append(menu.shell, item);
 
 	// about
@@ -351,12 +351,12 @@ refresh_app_indicator()
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), enabled);
 			break;
 		case 1:
-			// quiet button
-			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_quiet);
-			break;
-		case 2:
 			// fullscreen button
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_window);
+			break;
+		case 2:
+			// passive button
+			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_passive);
 			break;
 		default:
 			// delete all other GtkTypeCheckMenuItem objects
@@ -692,10 +692,10 @@ squint_disable()
 GOptionEntry option_entries[] = {
   { "disable",	'd',	0,	G_OPTION_ARG_NONE,	&config.opt_disable,	"Do not enable screen duplication at startup", NULL},
   { "limit",	'l',	0,	G_OPTION_ARG_INT,	&config.opt_limit,	"Limit refresh rate to N frames per second", "N"},
+  { "passive",	'p',	0,	G_OPTION_ARG_NONE,	&config.opt_passive,	"Do not raise the window on user activity", NULL},
   { "rate",	'r',	0,	G_OPTION_ARG_INT,	&config.opt_rate,	"Use fixed refresh rate of N frames per second", "N"},
   { "version",	'v',	0,	G_OPTION_ARG_NONE,	&config.opt_version,	"Display version information and exit", NULL},
   { "window",	'w',	0,	G_OPTION_ARG_NONE,	&config.opt_window,	"Run inside a window instead of going fullscreen", NULL},
-  { "quiet",	'q',	0,	G_OPTION_ARG_NONE,	&config.opt_quiet,	"Do not raise the window on activity", NULL},
   { NULL }
 };
 

--- a/squint.c
+++ b/squint.c
@@ -88,7 +88,9 @@ squint_show()
 		if (fullscreen) {
 			gtk_widget_show(gtkwin);
 		} else {
-			gdk_window_raise(gdkwin);
+      if (!config.opt_quiet) {
+        gdk_window_raise(gdkwin);
+      }
 		}
 	}
 }
@@ -100,7 +102,9 @@ do_hide()
 	if (fullscreen) {
 		gtk_widget_hide(gtkwin);
 	} else {
-		gdk_window_lower(gdkwin);
+    if (!config.opt_quiet) {
+      gdk_window_lower(gdkwin);
+    }
 	}
 }
 
@@ -139,6 +143,7 @@ on_window_delete_event(GtkWidget* widget, GdkEvent* event, gpointer data)
 #define ITEM_MASK		0xffffff00
 #define ITEM_ENABLE		(1<<8)
 #define ITEM_FULLSCREEN		(1<<9)
+#define ITEM_QUIET		(1<<14)
 #define ITEM_QUIT		(1<<10)
 #define ITEM_SRC_MONITOR	(1<<11)
 #define ITEM_DST_MONITOR	(1<<12)
@@ -178,7 +183,11 @@ on_menu_item_activate(gpointer pointer, gpointer user_data)
 			squint_enable();
 		}
 		break;
-	
+
+	case ITEM_QUIET:
+		config.opt_quiet = !config.opt_quiet;
+		goto reset;
+
 	case ITEM_FULLSCREEN:
 		config.opt_window = !config.opt_window;
 		goto reset;
@@ -286,12 +295,18 @@ init_app_indicator()
 	gtk_menu_shell_append(menu.shell, item);
 	GtkWidget* enabled_item = item;
 
+	// quiet
+	item = gtk_check_menu_item_new_with_label("Quiet");
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_quiet);
+	connect_menu_item(item, ITEM_QUIET);
+	gtk_menu_shell_append(menu.shell, item);
+
 	// fullscreen
 	item = gtk_check_menu_item_new_with_label("Fullscreen");
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_window);
 	connect_menu_item(item, ITEM_FULLSCREEN);
 	gtk_menu_shell_append(menu.shell, item);
-	
+
 	// about
 	item = gtk_menu_item_new_with_label("About");
 	connect_menu_item(item, ITEM_ABOUT);
@@ -340,6 +355,10 @@ refresh_app_indicator()
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), enabled);
 			break;
 		case 1:
+			// quiet button
+			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), config.opt_quiet);
+			break;
+		case 2:
 			// fullscreen button
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), !config.opt_window);
 			break;
@@ -680,6 +699,7 @@ GOptionEntry option_entries[] = {
   { "rate",	'r',	0,	G_OPTION_ARG_INT,	&config.opt_rate,	"Use fixed refresh rate of N frames per second", "N"},
   { "version",	'v',	0,	G_OPTION_ARG_NONE,	&config.opt_version,	"Display version information and exit", NULL},
   { "window",	'w',	0,	G_OPTION_ARG_NONE,	&config.opt_window,	"Run inside a window instead of going fullscreen", NULL},
+  { "quiet",	'q',	0,	G_OPTION_ARG_NONE,	&config.opt_quiet,	"Do not raise the window on activity", NULL},
   { NULL }
 };
 

--- a/squint.h
+++ b/squint.h
@@ -8,7 +8,7 @@ extern struct config {
 	const char* src_monitor_name;
 	const char* dst_monitor_name;
 
-	gboolean opt_version, opt_window, opt_disable;
+	gboolean opt_version, opt_window, opt_disable, opt_quiet;
 	gint opt_limit, opt_rate;
 } config;
 

--- a/squint.h
+++ b/squint.h
@@ -8,7 +8,7 @@ extern struct config {
 	const char* src_monitor_name;
 	const char* dst_monitor_name;
 
-	gboolean opt_version, opt_window, opt_disable, opt_quiet;
+	gboolean opt_version, opt_window, opt_disable, opt_passive;
 	gint opt_limit, opt_rate;
 } config;
 

--- a/x11.c
+++ b/x11.c
@@ -514,6 +514,9 @@ x11_active_window_start_monitoring()
 	if (active_window)
 		x11_active_window_stop_monitoring();
 
+	if (config.opt_passive)
+		return;
+
 	active_window = x11_get_active_window();
 	if (!active_window)
 		return;
@@ -693,7 +696,9 @@ x11_set_xi_eventmask(gboolean active)
 	if (active) {
 		// select for button and key events from all master devices
 		XISetMask(mask1, XI_RawMotion);
-		XISetMask(mask1, XI_RawKeyPress);
+		if (!config.opt_passive) {
+			XISetMask(mask1, XI_RawKeyPress);
+		}
 	}
 
 	evmasks[0].deviceid = XIAllMasterDevices;
@@ -1077,6 +1082,9 @@ void
 x11_enable_focus_tracking()
 {
 	memset(&active_window_rect, 0, sizeof(active_window_rect));
+
+	if (config.opt_passive)
+		return;
 
 	XSetWindowAttributes attr;
 	attr.event_mask = PropertyChangeMask;


### PR DESCRIPTION
Hi there @a-ba, 

Nice project! 

I'm using i3wm and when working in windowed mode squint "steals" the focus from source monitor because i3wm by default changes focus to the window requiring attention. 

Added quiet mode so that squint works well without dropping focus of the source monitor.

Let me know what you think about this. 